### PR TITLE
melhoras no get_trie.py e adicionado query_trie.py, com instruçoes em README_trie_python

### DIFF
--- a/src/README_trie_python.txt
+++ b/src/README_trie_python.txt
@@ -1,0 +1,67 @@
+
+Tenha os arquivo "entities.txt" e o aquivo "sentences.txt" presente na mesma pasta do seu query_trie.py
+
+1.O arquivo entidades.txt é um arquivos que possui sua lista de entidades, com uma entidade por linha. Exemplo de arquivo entities.txt:
+Joao
+Joao Mario
+Joao Rabelo
+Mario Lucas
+Mario Jorge
+FGV
+Rio de Janeiro
+
+2.O arquivo senteces.txt é um simples txt com uma sentença por linha. Exemplo de arquivo sentences:
+Rio de Janeiro é a melhor cidade do mundo.
+FGV anuncia cortes nos salários dos funcionários.
+Nunca antes Joao correu tanto.
+Bandidos causam terror no Rio de Janeiro.
+Joao Mario e Mario Lucas são melhores amigos.
+joao mario.
+mario gosta de comer carne.
+Rio de Janeiro é a melhor cidade do mundo.
+Joao e Guilherme tomam café na FGV todos os dias, mas Joao sempre toma mais.
+
+3.No terminal, use o comando: 
+	
+	python get_trie.py entities.txt trie.txt
+
+O aquivo obtido trie.txt será da forma:
+
+{
+    "rio": {
+        "de": {
+            "janeiro": {
+                "finish": {}
+            }
+        }
+    },
+    "mario": {
+        "jorge": {
+            "finish": {}
+        },
+        "lucas": {
+            "finish": {}
+        }
+    },
+    "joao": {
+        "finish": {},
+        "mario": {
+            "finish": {}
+        },
+        "rabelo": {
+            "finish": {}
+        }
+    },
+    "fgv": {
+        "finish": {}
+    }
+}
+
+4. Rode o query_trie.py fazendo o comando: 
+
+python query_trie.py
+
+O programa irá retornar dois resultados:
+
+	1 - Um Counter com o número sentenças em que cada entidade aparece na lista de sentenças.
+	2 - Um dicionário com o as entidades como key mapeadas a um vetor  (id, posicao), onde id é o número da sentença no documento (no caso o número da linha do documento) e id a posição da palavra naquela sentença. Ambos os valores são relativos a uma contagem iniciada em 0.

--- a/src/get_trie.py
+++ b/src/get_trie.py
@@ -5,6 +5,7 @@ import json
 class BuildTrie():
     def __init__(self, file_path: str):
         self.file_path = file_path
+        self.name_finish = "finish"
 
     def get_parsed_name_list(self) -> list:
         parsed_name_list = list()
@@ -13,13 +14,15 @@ class BuildTrie():
                 line_list = file.readlines()
             for line in line_list:
                 parsed_name = list(map(lambda x: x.lower(), line.split(' ')))
-                parsed_name[-1] = parsed_name[-1][:-1]
+                parsed_name[-1] = parsed_name[-1].replace("\n","")
                 parsed_name_list.append(parsed_name)
         else:
             print('Path does not exists!')
         return parsed_name_list
 
     def build_trie(self, trie_dict: dict, name_list: list, layer: int) -> dict:
+        if layer == len(name_list):
+            trie_dict[self.name_finish] = {}
         if layer >= len(name_list):
             return trie_dict
         if name_list[layer] not in trie_dict:

--- a/src/query_trie.py
+++ b/src/query_trie.py
@@ -1,0 +1,56 @@
+from collections import Counter, defaultdict
+import ast
+
+#load trie
+with open('trie.txt','r') as inf:
+    trie = ast.literal_eval(inf.read())
+
+#load sentences.txt
+with open('sentences.txt','r') as sentence_file:
+    sentences_vec = sentence_file.read().splitlines()
+
+
+def wordInTrie(trie,pos: int ,entidade: list) -> bool: #recebe como parametro a trie, a posição na sentença e a entidade de retorno
+    if pos >= len(sentenceVector):
+        return False
+    
+    word = sentenceVector[pos]
+    if 'finish' in trie and word not in trie:
+        return True
+    
+    if word not in trie:
+        return False
+    
+    entidade.append(word)
+    entidade_aux = []
+    
+    if(wordInTrie(trie[word],pos+1,entidade_aux)):
+        entidade += entidade_aux
+        return True
+    
+    return 'finish' in trie
+
+c = Counter()
+places = defaultdict(list)
+
+
+# For loop que transforma cada linha (sentença) do txt em um SentenceVector (vetor de palavra da sentença) e cria um contador "c" e um defaultdict "places"
+# c --> Counter {entidade: n}  onde "n" é número de sentenças em sentences.txt que possui a entidade. 
+# places --> dicionário das posiçoes das entidades no documento sentences.txt. {entidade: (id_da_sentença, posição_na_sentença)} 
+
+for line_id, sentence in enumerate(sentences_vec): # sentences_vec= documento com todas as sentencas  (uma em cada linha) em formato de vetor
+    sentenceVector = [word.lower() for word in sentence.split(' ')]
+    end = -1
+    for i, word in enumerate(sentenceVector):
+        if i <= end:
+            continue
+        entidade = []
+        boolean  = wordInTrie(trie,i,entidade)
+        if boolean:
+            end = i+len(entidade)-1
+            entidade_palavra = ' '.join(entidade)
+            c[entidade_palavra] += 1
+            places[entidade_palavra].append((line_id,i))
+
+print(c)
+print(places)


### PR DESCRIPTION
Corrigi dois erros que a primeira versão tinha:

Erro1: Trie igual para uma lista1: [Joao, Joao Lucas, Joao Mario] e lista2: [Joao Lucas, Joao Mario]
Solução: Criei um nó "finish" pra o qual todo nó folha aponta, isso demarca as entidades na lista.

Erro2: Última letra da última entidade estava sendo cortada na geração da Trie:
Solução: trocar "parsed_name[-1] = parsed_name[-1][:-1]" por 
parsed_name[-1] = parsed_name[-1].replace("\n","")
